### PR TITLE
added AWS Blockchain Node Runners Blueprint for Ethereum

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -466,6 +466,7 @@ As part of your monitoring, make sure to keep an eye on your machine's performan
 
 ## Further reading {#further-reading}
 
+- [Sample AWS Blockchain Node Runner app for Ethereum Nodes](https://aws-samples.github.io/aws-blockchain-node-runners/docs/Blueprints/Ethereum) - _AWS, updated often_
 - [Ethereum Staking Guides](https://github.com/SomerEsat/ethereum-staking-guides) - _Somer Esat, updated often_
 - [Guide | How to setup a validator for Ethereum staking on mainnet](https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet) _– CoinCashew, updated regularly_
 - [ETHStaker guides on running validators on testnets](https://github.com/remyroy/ethstaker#guides) – _ETHStaker, updated regularly_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I added a link to the documentation for how deploy self managed Ethereum nodes on AWS.
## Description

<!--- Describe your changes in detail -->
I added a link to the AWS Blockchain Node Runners Blueprint for Ethereum in order to showcase a self managed way in which you can deploy your Ethereum Nodes on AWS (without using Amazon Managed Blockchain). AWS Blockchain Node Runners is an open-source project that provides developers with a set of TypeScript CDK blueprints. These blueprints can be used to deploy nodes for various blockchain protocols, including Ethereum, on AWS infrastructure.


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
